### PR TITLE
Correct throttle suffix when the method is not called with kwargs

### DIFF
--- a/src/davinci_crawling/throttle/tests/test_redis_throttle.py
+++ b/src/davinci_crawling/throttle/tests/test_redis_throttle.py
@@ -15,12 +15,6 @@ CHROME_OPTIONS = {
 
 
 class TestRedisThrottle(CaravaggioBaseTest):
-    """
-    Test the proxy logic, this test requires connection with internet
-    because we use the proxy mesh api and request for real pages.
-    """
-
-    all_files_count = 0
 
     @classmethod
     def setUpTestData(cls):

--- a/src/davinci_crawling/throttle/tests/test_throttle.py
+++ b/src/davinci_crawling/throttle/tests/test_throttle.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 BuildGroup Data Services Inc.
+import logging
+import time
+
+from caravaggio_rest_api.tests import CaravaggioBaseTest
+from davinci_crawling.throttle.throttle import Throttle
+from django.conf import settings
+
+_logger = logging.getLogger("davinci_crawling.testing")
+
+CHROME_OPTIONS = {
+    "chromium_bin_file": settings.CHROMIUM_BIN_FILE
+}
+
+
+class TestThrottle(CaravaggioBaseTest):
+    @classmethod
+    def setUpTestData(cls):
+        pass
+
+    def test_method_with_kwargs(self):
+        @Throttle(crawler_name="test_kwargs", seconds=10, max_tokens=25,
+                  rate=25, throttle_suffix_field="suffix")
+        def throttle_method(prefix, suffix, print_name):
+            print("%s %s %s" % (prefix, print_name, suffix))
+
+        suffixes = ["from Brazil", "from USA"]
+        start = time.time()
+        for index in range(50):
+            suffix = suffixes[index % 2]
+            throttle_method("Mr.", suffix=suffix, print_name="John%d" % index)
+        end = time.time()
+        total = end - start
+
+        self.assertTrue(10 < total < 20)
+
+    def test_method_with_args(self):
+        @Throttle(crawler_name="test_args", seconds=10, max_tokens=25, rate=25,
+                  throttle_suffix_field="suffix")
+        def throttle_method(prefix, suffix, print_name):
+            print("%s %s %s" % (prefix, print_name, suffix))
+
+        suffixes = ["from Brazil", "from USA"]
+        start = time.time()
+        for index in range(50):
+            suffix = suffixes[index % 2]
+            throttle_method("Mr.", suffix, "John%d" % index)
+        end = time.time()
+        total = end - start
+
+        self.assertTrue(10 < total < 20)

--- a/src/davinci_crawling/throttle/throttle.py
+++ b/src/davinci_crawling/throttle/throttle.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2019 BuildGroup Data Services Inc.
 
 # https://quentin.pradet.me/blog/how-do-you-rate-limit-calls-with-aiohttp.html
+import inspect
 from abc import ABC, abstractmethod
 from datetime import timedelta
 from functools import wraps
@@ -69,6 +70,13 @@ class Throttle(object):
             throttle_suffix = None
             if self.suffix_field:
                 throttle_suffix = kwargs.get(self.suffix_field)
+
+                if not throttle_suffix:
+                    arguments = inspect.getfullargspec(fn).args
+                    if self.suffix_field in arguments:
+                        argument_position = arguments.index(self.suffix_field)
+                        if argument_position < len(args):
+                            throttle_suffix = args[argument_position]
 
             manager = self.get_throttle_manager()
 


### PR DESCRIPTION
Correct a bug on the @Throttle decorator that was not considering the arguments when we call the method without kwargs.